### PR TITLE
Fix icon loading by fetching SVGs dynamically

### DIFF
--- a/index.html
+++ b/index.html
@@ -448,26 +448,43 @@
       addEventListener('resize', resize); addEventListener('orientationchange', resize); resize();
       const rand = (a,b)=> a + Math.random()*(b-a); const pick = a => a[Math.floor(Math.random()*a.length)];
       
-async function fromSymbol(name, color) {
-  const g = document.createElementNS(svgNS, 'g');
-  try {
-    const res = await fetch(`icons/${name}.svg`);
-    const svgText = await res.text();
-    const temp = document.createElement('div');
-    temp.innerHTML = svgText;
-    const fetchedSvg = temp.querySelector('svg');
-    if (fetchedSvg) {
-      for (const child of fetchedSvg.children) {
-        const clone = child.cloneNode(true);
-        clone.setAttribute('stroke', color);
-        g.appendChild(clone);
+  async function fromSymbol(name, color) {
+    const g = document.createElementNS(svgNS, 'g');
+    try {
+      const res = await fetch(`icons/${name}.svg`);
+      const svgText = await res.text();
+      const temp = document.createElement('div');
+      temp.innerHTML = svgText;
+      const fetchedSvg = temp.querySelector('svg');
+      if (fetchedSvg) {
+        for (const child of fetchedSvg.children) {
+          const clone = child.cloneNode(true);
+          clone.setAttribute('stroke', color);
+          clone.setAttribute('fill', color);
+          g.appendChild(clone);
+        }
       }
+    } catch (e) {
+      console.error("Failed to load /icons/" + name + ".svg", e);
     }
-  } catch (e) {
-    console.error("Failed to load /icons/" + name + ".svg", e);
+    return g;
   }
-  return g;
-}
+
+  async function spawnIcons() {
+    for (let i = 0; i < CFG.count; i++) {
+      const name = pick(ICONS);
+      const color = pick(COLORS);
+      const g = await fromSymbol(name, color);
+      const svg = document.createElementNS(svgNS, 'svg');
+      const size = rand(CFG.minSize, CFG.maxSize);
+      svg.setAttribute('width', size);
+      svg.setAttribute('height', size);
+      svg.appendChild(g);
+      layer.appendChild(svg);
+      icons.push(svg);
+    }
+  }
+  spawnIcons();
 })();                  <!-- close the IIFE -->
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Load SVG icons on page start and inject them into the overlay layer
- Colorize fetched icons to match theme

## Testing
- `npx --yes html-validate index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688e7f07e7008329a9691278098f1403